### PR TITLE
Make directory and decision record template configurable via yaml config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ After of install this project you may execute the binary `phpadr` in your termin
 
 If to execute the command above, it will be showd a list of all avaliable tool commands.
 
-By default the records will be stored in `docs/arch`, to change this workspace use the option `--directory` with the path of the new workspace.
+By default the records will be stored in `docs/arch`, to change this workspace use the option `--config` with the path of the config file.
 
 ### Create a new ADR
 
 You may use the `make:decision` command:
 
 ```
-./vendor/bin/phpadr make:decision <title> [<status="Accepted">] [--directory="docs/arch"]
+./vendor/bin/phpadr make:decision <title> [<status="Accepted">] [--config="adr.yml"]
 ```
 
 ### Count the ADRs
@@ -47,7 +47,7 @@ You may use the `make:decision` command:
 You may use the `workspace:count` command:
 
 ```
-./vendor/bin/phpadr workspace:count [--directory="docs/arch"]
+./vendor/bin/phpadr workspace:count [--config="adr.yml"]
 ```
 
 ### List the ADRs
@@ -55,7 +55,7 @@ You may use the `workspace:count` command:
 You may use the `workspace:list` command:
 
 ```
-./vendor/bin/phpadr workspace:list [--directory="docs/arch"]
+./vendor/bin/phpadr workspace:list [--config="adr.yml"]
 ```
 
 ### Help

--- a/adr.yml
+++ b/adr.yml
@@ -1,0 +1,3 @@
+directory: docs/arch
+template:
+  decision-record: template/skeleton.md

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     "require": {
         "php": "^7.1.3",
         "ext-mbstring": "*",
-        "symfony/console": "^4.0"
+        "symfony/console": "^4.0",
+        "symfony/yaml": "^4.2@dev"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "c3bbdef9c41abf466c4da6cd00000c8d",
+    "content-hash": "936670ff7fa796bd74a08f053c678976",
     "packages": [
         {
             "name": "symfony/console",
@@ -72,7 +72,65 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2018-04-01 08:27:13"
+            "time": "2018-04-01T08:27:13+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "9d31bef82d2e9b033f335d60b96611757f98c605"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/9d31bef82d2e9b033f335d60b96611757f98c605",
+                "reference": "9d31bef82d2e9b033f335d60b96611757f98c605",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                },
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "time": "2018-05-17T18:32:56+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -131,7 +189,66 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-01-30 19:27:44"
+            "time": "2018-01-30T19:27:44+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "baca29061390e4390ad5957d5b7d95cb8fb2e98c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/baca29061390e4390ad5957d5b7d95cb8fb2e98c",
+                "reference": "baca29061390e4390ad5957d5b7d95cb8fb2e98c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "conflict": {
+                "symfony/console": "<3.4"
+            },
+            "require-dev": {
+                "symfony/console": "~3.4|~4.0"
+            },
+            "suggest": {
+                "symfony/console": "For validating YAML files using the lint command"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-05-31T10:18:23+00:00"
         }
     ],
     "packages-dev": [
@@ -2069,64 +2186,6 @@
             "time": "2018-02-19T16:51:42+00:00"
         },
         {
-            "name": "symfony/yaml",
-            "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "90fbbce247c1bfc12c6618c047d62c288c79e49c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/90fbbce247c1bfc12c6618c047d62c288c79e49c",
-                "reference": "90fbbce247c1bfc12c6618c047d62c288c79e49c",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1.3"
-            },
-            "conflict": {
-                "symfony/console": "<3.4"
-            },
-            "require-dev": {
-                "symfony/console": "~3.4|~4.0"
-            },
-            "suggest": {
-                "symfony/console": "For validating YAML files using the lint command"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.1-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Yaml\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony Yaml Component",
-            "homepage": "https://symfony.com",
-            "time": "2018-02-22T11:40:25+00:00"
-        },
-        {
             "name": "theseer/tokenizer",
             "version": "1.1.0",
             "source": {
@@ -2220,6 +2279,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "symfony/yaml": 20,
         "mikey179/vfsstream": 20
     },
     "prefer-stable": false,

--- a/docs/arch/0005-phpunit-as-testing-framework.md
+++ b/docs/arch/0005-phpunit-as-testing-framework.md
@@ -16,6 +16,6 @@ It will be used the [PHPUnit](https://phpunit.de/) as testing framework.
 
 ## Consequences
 
-Use unit testing for ensure that the code is working as expected and that changes don't break existing funcionality.
+Use unit testing for ensure that the code is working as expected and that changes don't break existing functionality.
 
 Allow to use Test-Driven Development (TDD) that is an evolutionary approach to development which combines test-first development.

--- a/docs/arch/0006-yaml-as-configuration-file.md
+++ b/docs/arch/0006-yaml-as-configuration-file.md
@@ -1,0 +1,21 @@
+# 6. YAML as configuration file
+
+Date: 2018-06-30
+
+## Status
+
+Accepted
+
+## Context
+
+In order to use a custom ADR template, it must be possible to configure the path to it. The same template must be used so that all ADR`s are structured in the same way.
+
+## Decision
+
+The template path can be defined via a [YAML](http://yaml.org/) configuration file.
+
+## Consequences
+
+We need to add [symfony/yaml](https://github.com/symfony/yaml) as a dependency to the project.
+
+To have a single place of truth the "directory" option must be removed from all console commands, because the directory can be defined in the configuration file.

--- a/src/Command/MakeDecisionCommand.php
+++ b/src/Command/MakeDecisionCommand.php
@@ -2,16 +2,16 @@
 
 namespace ADR\Command;
 
+use ADR\Domain\DecisionContent;
+use ADR\Domain\DecisionRecord;
+use ADR\Domain\Sequence;
 use ADR\Filesystem\Config;
+use ADR\Filesystem\Workspace;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use ADR\Filesystem\Workspace;
-use ADR\Domain\Sequence;
-use ADR\Domain\DecisionRecord;
-use ADR\Domain\DecisionContent;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Command to make ADRs

--- a/src/Command/MakeDecisionCommand.php
+++ b/src/Command/MakeDecisionCommand.php
@@ -44,7 +44,7 @@ class MakeDecisionCommand extends Command
                 'status',
                 InputArgument::OPTIONAL,
                 sprintf(
-                   'The status of the ADR, avaliable options: [%s]',
+                   'The status of the ADR, available options: [%s]',
                    implode(', ', $options)
                 ),
                 DecisionContent::STATUS_ACCEPTED

--- a/src/Command/MakeDecisionCommand.php
+++ b/src/Command/MakeDecisionCommand.php
@@ -2,6 +2,7 @@
 
 namespace ADR\Command;
 
+use ADR\Filesystem\Config;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -50,11 +51,11 @@ class MakeDecisionCommand extends Command
                 DecisionContent::STATUS_ACCEPTED
             )
             ->addOption(
-                'directory',
+                'config',
                 null,
                 InputOption::VALUE_REQUIRED,
-                'Workspace that store the ADRs',
-                'docs/arch'
+                'Config file',
+                'adr.yml'
             );
     }
 
@@ -66,10 +67,11 @@ class MakeDecisionCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $workspace = new Workspace($input->getOption('directory'));
+        $config = new Config($input->getOption('config'));
+        $workspace = new Workspace($config->directory());
         $sequence = new Sequence($workspace);
         $content = new DecisionContent($sequence->next(), $input->getArgument('title'), $input->getArgument('status'));
-        $record = new DecisionRecord($content);
+        $record = new DecisionRecord($content, $config);
         
         $workspace->add($record);
         

--- a/src/Command/WorkspaceCountCommand.php
+++ b/src/Command/WorkspaceCountCommand.php
@@ -3,16 +3,16 @@
 namespace ADR\Command;
 
 use ADR\Filesystem\Config;
+use ADR\Filesystem\Workspace;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use ADR\Filesystem\Workspace;
 
 /**
  * Command to count ADRs in workspace
- * 
+ *
  * @author José Carlos <josecarlos@globtec.com.br>
  */
 class WorkspaceCountCommand extends Command
@@ -34,11 +34,11 @@ class WorkspaceCountCommand extends Command
                 'adr.yml'
             );
     }
-    
+
     /**
      * Execute the command
      *
-     * @param InputInterface  $input
+     * @param InputInterface $input
      * @param OutputInterface $output
      */
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/src/Command/WorkspaceCountCommand.php
+++ b/src/Command/WorkspaceCountCommand.php
@@ -2,6 +2,7 @@
 
 namespace ADR\Command;
 
+use ADR\Filesystem\Config;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
@@ -26,11 +27,11 @@ class WorkspaceCountCommand extends Command
             ->setDescription('Count the ADRs')
             ->setHelp('This command allows you count the ADRs')
             ->addOption(
-                'directory',
+                'config',
                 null,
                 InputOption::VALUE_REQUIRED,
-                'Workspace that store the ADRs',
-                'docs/arch'
+                'Config file',
+                'adr.yml'
             );
     }
     
@@ -42,8 +43,9 @@ class WorkspaceCountCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $config = new Config($input->getOption('config'));
         $style = new SymfonyStyle($input, $output);
-        $workspace = new Workspace($input->getOption('directory'));
+        $workspace = new Workspace($config->directory());
 
         $style->table(['Count'], [[$workspace->count()]]);
     }

--- a/src/Command/WorkspaceListCommand.php
+++ b/src/Command/WorkspaceListCommand.php
@@ -2,6 +2,7 @@
 
 namespace ADR\Command;
 
+use ADR\Filesystem\Config;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
@@ -26,11 +27,11 @@ class WorkspaceListCommand extends Command
             ->setDescription('List the ADRs')
             ->setHelp('This command allows you list the ADRs')
             ->addOption(
-                'directory',
+                'config',
                 null,
                 InputOption::VALUE_REQUIRED,
-                'Workspace that store the ADRs',
-                'docs/arch'
+                'Config file',
+                'adr.yml'
             );
     }
     
@@ -42,7 +43,8 @@ class WorkspaceListCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $workspace = new Workspace($input->getOption('directory'));
+        $config = new Config($input->getOption('config'));
+        $workspace = new Workspace($config->directory());
         
         $records = $workspace->records();
         

--- a/src/Command/WorkspaceListCommand.php
+++ b/src/Command/WorkspaceListCommand.php
@@ -3,16 +3,16 @@
 namespace ADR\Command;
 
 use ADR\Filesystem\Config;
+use ADR\Filesystem\Workspace;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use ADR\Filesystem\Workspace;
 
 /**
  * Command to list ADRs in workspace
- * 
+ *
  * @author José Carlos <josecarlos@globtec.com.br>
  */
 class WorkspaceListCommand extends Command
@@ -34,29 +34,31 @@ class WorkspaceListCommand extends Command
                 'adr.yml'
             );
     }
-    
+
     /**
      * Execute the command
      *
-     * @param InputInterface  $input
+     * @param InputInterface $input
      * @param OutputInterface $output
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $config = new Config($input->getOption('config'));
         $workspace = new Workspace($config->directory());
-        
+
         $records = $workspace->records();
-        
+
         asort($records);
-        
+
         if (empty($records)) {
             $output->writeln('<info>Workspace is empty</info>');
         } else {
             $style = new SymfonyStyle($input, $output);
             $style->table(
-                ['Filename'], 
-                array_map(function ($record) { return [$record]; }, $records)
+                ['Filename'],
+                array_map(function ($record) {
+                    return [$record];
+                }, $records)
             );
         }
     }

--- a/src/Domain/DecisionContent.php
+++ b/src/Domain/DecisionContent.php
@@ -5,7 +5,7 @@ namespace ADR\Domain;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
 
 /**
- * Representes value object of the architecture decision
+ * Represents value object of the architecture decision
  * 
  * @author José Carlos <josecarlos@globtec.com.br>
  */
@@ -157,7 +157,7 @@ class DecisionContent
     }
     
     /**
-     * Determines whether the title is greater than maximun length set
+     * Determines whether the title is greater than maximum length set
      * 
      * @param string $title
      * 

--- a/src/Domain/DecisionContent.php
+++ b/src/Domain/DecisionContent.php
@@ -6,7 +6,7 @@ use Symfony\Component\Console\Exception\InvalidArgumentException;
 
 /**
  * Represents value object of the architecture decision
- * 
+ *
  * @author José Carlos <josecarlos@globtec.com.br>
  */
 class DecisionContent
@@ -15,52 +15,52 @@ class DecisionContent
      * @var integer
      */
     const TITLE_MAX_LENGTH = 100;
-    
+
     /**
      * If the project stakeholders haven't agreed with it yet
-     * 
+     *
      * @var string
      */
     const STATUS_PROPOSED = 'Proposed';
-    
+
     /**
      * Once it is agreed
-     * 
+     *
      * @var string
      */
     const STATUS_ACCEPTED = 'Accepted';
-    
+
     /**
      * If a later ADR changes or reverses a decision to declined
-     * 
+     *
      * @var string
      */
     const STATUS_REJECTED = 'Rejected';
-    
+
     /**
      * If a later ADR changes or reverses a decision to deprecated
-     * 
+     *
      * @var string
      */
     const STATUS_DEPRECATED = 'Deprecated';
-    
+
     /**
      * @var int
      */
     private $id;
-    
+
     /**
      * @var string
      */
     private $title;
-    
+
     /**
      * @var string
      */
     private $status;
-    
+
     /**
-     * @param int    $id
+     * @param int $id
      * @param string $title
      * @param string $status
      *
@@ -69,41 +69,41 @@ class DecisionContent
     public function __construct(int $id, string $title, string $status = self::STATUS_ACCEPTED)
     {
         $this->id = $id;
-        
+
         $this->setTitle($title);
         $this->setStatus($status);
     }
-    
+
     /**
      * Returns the number of the ADR
-     * 
+     *
      * @return int ID value
      */
     public function getId(): int
     {
         return $this->id;
     }
-    
+
     /**
      * Returns the title
-     * 
+     *
      * @return string The title
      */
     public function getTitle(): string
     {
         return $this->title;
     }
-    
+
     /**
      * Returns the status
-     * 
+     *
      * @return string The status
      */
     public function getStatus(): string
     {
         return $this->status;
     }
-    
+
     /**
      * Set title
      *
@@ -118,16 +118,16 @@ class DecisionContent
                 'The title must be less than or equal to %d characters',
                 self::TITLE_MAX_LENGTH
             );
-            
+
             throw new InvalidArgumentException($message);
         }
-        
+
         $this->title = $title;
     }
-    
+
     /**
-     * Set status 
-     * 
+     * Set status
+     *
      * @param string $status Decision status
      *
      * @throws InvalidArgumentException
@@ -140,27 +140,27 @@ class DecisionContent
             self::STATUS_REJECTED,
             self::STATUS_DEPRECATED,
         ];
-        
+
         $key = array_search(strtolower($status), array_map('strtolower', $statuses));
-        
+
         if (false === $key) {
             $message = sprintf(
                 'Invalid status "%s". Available status: [%s]',
                 $status,
                 implode(', ', $statuses)
             );
-            
+
             throw new InvalidArgumentException($message);
         }
-        
+
         $this->status = $statuses[$key];
     }
     
     /**
      * Determines whether the title is greater than maximum length set
-     * 
+     *
      * @param string $title
-     * 
+     *
      * @return bool
      */
     private function isGreaterThanTitleMaxLenght(string $title): bool

--- a/src/Domain/DecisionRecord.php
+++ b/src/Domain/DecisionRecord.php
@@ -2,6 +2,8 @@
 
 namespace ADR\Domain;
 
+use ADR\Filesystem\Config;
+
 /**
  * Represents the architecture decision using text formatting language like Markdown
  * 
@@ -22,18 +24,25 @@ class DecisionRecord
      * @var int
      */
     const NUMBER_LENGTH = 4;
-    
+
     /**
      * @var DecisionContent
      */
     private $content;
+
+    /**
+     * @var Config
+     */
+    private $config;
     
     /**
      * @param DecisionContent $content
+     * @param Config          $config
      */
-    public function __construct(DecisionContent $content)
+    public function __construct(DecisionContent $content, Config $config)
     {
         $this->content = $content;
+        $this->config = $config;
     }
     
     /**
@@ -96,8 +105,8 @@ class DecisionRecord
     private function template(): string
     {
         ob_start();
-        
-        require realpath(__DIR__ . '/../../template/skeleton.md');
+
+        require realpath($this->config->decisionRecordTemplateFile());
         
         return ob_get_clean();
     }

--- a/src/Domain/Sequence.php
+++ b/src/Domain/Sequence.php
@@ -2,51 +2,51 @@
 
 namespace ADR\Domain;
 
-use Symfony\Component\Console\Exception\LogicException;
 use ADR\Filesystem\Workspace;
+use Symfony\Component\Console\Exception\LogicException;
 
 /**
  * Represents the numbered sequentially and monotonically
- * 
+ *
  * @author José Carlos <josecarlos@globtec.com.br>
  */
 class Sequence
 {
     /**
      * Max value to sequence
-     * 
+     *
      * @var integer
      */
     const MAX_VALUE = 9999;
-    
+
     /**
      * @var Workspace
      */
     private $workspace;
-    
+
     /**
      * @param Workspace $workspace
      */
     public function __construct(Workspace $workspace)
     {
-        $this->workspace = $workspace;    
+        $this->workspace = $workspace;
     }
-    
+
     /**
      * Create sequence monotonically, numbers will not be reused
-     * 
+     *
      * @throws LogicException
-     * 
+     *
      * @return int The next value in a sequence
      */
     public function next(): int
     {
         $sequence = $this->workspace->count() + 1;
-        
+
         if ($sequence > self::MAX_VALUE) {
             throw new LogicException('Next value exceeds the max value and cannot be used');
         }
-        
+
         return $sequence;
     }
 }

--- a/src/Filesystem/Config.php
+++ b/src/Filesystem/Config.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types=1);
+
+namespace ADR\Filesystem;
+
+use RuntimeException;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Represents the configuration of this project.
+ *
+ * @author Alexander Bachmann <a.t.bachmann@gmail.com>
+ */
+class Config
+{
+    /**
+     * @var array
+     */
+    private $data;
+
+    /**
+     * @param string $file
+     *
+     * @throws RuntimeException
+     */
+    public function __construct(string $file)
+    {
+        $this->parseFile($file);
+    }
+
+    /**
+     * Returns the ADR workspace directory
+     *
+     * @return string
+     */
+    public function directory(): string
+    {
+        return $this->data['directory'];
+    }
+
+    /**
+     * Returns the path to the decision record template
+     *
+     * @return string
+     */
+    public function decisionRecordTemplateFile(): string
+    {
+        return $this->data['template']['decision-record'];
+    }
+
+    /**
+     * @param string $file
+     *
+     * @throws RuntimeException If the file can not be processed
+     */
+    private function parseFile(string $file): void
+    {
+        if (! file_exists($file)) {
+            throw new RuntimeException("The config file does not exist: $file");
+        }
+
+        if (! is_readable($file)) {
+            throw new RuntimeException("The config file isn't readable: $file");
+        }
+
+        $this->data = Yaml::parseFile($file);
+    }
+}

--- a/src/Filesystem/Workspace.php
+++ b/src/Filesystem/Workspace.php
@@ -2,10 +2,10 @@
 
 namespace ADR\Filesystem;
 
-use Symfony\Component\Console\Exception\RuntimeException;
 use ADR\Domain\DecisionRecord;
 use FilesystemIterator;
 use SplFileInfo;
+use Symfony\Component\Console\Exception\RuntimeException;
 
 /**
  * Represents the workspace that store the ADRs

--- a/src/Filesystem/Workspace.php
+++ b/src/Filesystem/Workspace.php
@@ -123,7 +123,7 @@ class Workspace
     /**
      * Returns filename 
      * 
-     * @param RecordDecision $record
+     * @param DecisionRecord $record
      * 
      * @return string The filename
      */

--- a/src/Filesystem/Workspace.php
+++ b/src/Filesystem/Workspace.php
@@ -70,10 +70,10 @@ class Workspace
         
         $iterator = new FilesystemIterator($this->get(), FilesystemIterator::SKIP_DOTS);
         
-        /* @var $fileinfo SplFileInfo */
-        foreach ($iterator as $fileinfo) {
-            if ($this->isValidFilename($fileinfo)) {
-                array_push($records, $fileinfo->getFilename());
+        /* @var $fileInfo SplFileInfo */
+        foreach ($iterator as $fileInfo) {
+            if ($this->isValidFilename($fileInfo)) {
+                array_push($records, $fileInfo->getFilename());
             }
         }
         
@@ -135,18 +135,18 @@ class Workspace
     /**
      * Check if filename is valid to ADR
      * 
-     * @param SplFileInfo $fileinfo
+     * @param SplFileInfo $fileInfo
      * 
      * @return bool
      */
-    private function isValidFilename(SplFileInfo $fileinfo): bool
+    private function isValidFilename(SplFileInfo $fileInfo): bool
     {
-        if (! $fileinfo->isFile()) {
+        if (! $fileInfo->isFile()) {
             return false;
         }
         
         $pattern = '/^\d{' . DecisionRecord::NUMBER_LENGTH . '}-[a-z\d\-]+\\' . DecisionRecord::EXTENSION . '$/';
         
-        return (boolean) preg_match($pattern, $fileinfo->getFilename());
+        return (boolean) preg_match($pattern, $fileInfo->getFilename());
     }
 }

--- a/tests/Command/MakeDecisionCommandTest.php
+++ b/tests/Command/MakeDecisionCommandTest.php
@@ -10,6 +10,9 @@ use org\bovigo\vfs\vfsStream;
 
 class MakeDecisionCommandTest extends TestCase
 {
+    /**
+     * @var MakeDecisionCommand
+     */
     private $command;
 
     public function setUp()

--- a/tests/Command/MakeDecisionCommandTest.php
+++ b/tests/Command/MakeDecisionCommandTest.php
@@ -2,11 +2,11 @@
 
 namespace ADR\Command;
 
-use PHPUnit\Framework\TestCase;
-use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Application;
-use Symfony\Component\Console\Tester\CommandTester;
 use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
 
 class MakeDecisionCommandTest extends TestCase
 {
@@ -39,64 +39,68 @@ class MakeDecisionCommandTest extends TestCase
     {
         $this->assertEquals('This command allows you to create a new ADR', $this->command->getHelp());
     }
-    
+
     public function testArguments()
     {
         $this->assertTrue($this->command->getDefinition()->hasArgument('title'));
         $this->assertTrue($this->command->getDefinition()->hasArgument('status'));
-        
+
         $this->assertCount(2, $this->command->getDefinition()->getArguments());
     }
-    
+
     public function testArgumentTitle()
     {
         $argument = $this->command->getDefinition()->getArgument('title');
-        
+
         $this->assertTrue($argument->isRequired());
         $this->assertEquals('The title of the ADR', $argument->getDescription());
         $this->assertNull($argument->getDefault());
     }
-    
+
     public function testArgumentStatus()
     {
         $argument = $this->command->getDefinition()->getArgument('status');
-        
+
         $this->assertFalse($argument->isRequired());
-        $this->assertEquals('The status of the ADR, available options: [Proposed, Accepted, Rejected, Deprecated]', $argument->getDescription());
+        $this->assertEquals('The status of the ADR, available options: [Proposed, Accepted, Rejected, Deprecated]',
+            $argument->getDescription());
         $this->assertEquals('Accepted', $argument->getDefault());
     }
-    
+
     public function testOptions()
     {
-        $this->assertTrue($this->command->getDefinition()->hasOption('directory'));
-        
+        $this->assertTrue($this->command->getDefinition()->hasOption('config'));
+
         $this->assertCount(1, $this->command->getDefinition()->getOptions());
     }
-    
-    public function testOptionDirectory()
+
+    public function testOptionConfig()
     {
-        $option = $this->command->getDefinition()->getOption('directory');
-        
+        $option = $this->command->getDefinition()->getOption('config');
+
         $this->assertNull($option->getShortcut());
         $this->assertTrue($option->isValueRequired());
-        $this->assertEquals('Workspace that store the ADRs', $option->getDescription());
-        $this->assertEquals('docs/arch', $option->getDefault());
+        $this->assertEquals('Config file', $option->getDescription());
+        $this->assertEquals('adr.yml', $option->getDefault());
     }
-    
+
     public function testExecute()
     {
         $vfs = vfsStream::setup();
-        
+        $configContent = file_get_contents('adr.yml');
+        $configContent = str_replace('docs/arch', $vfs->url(), $configContent);
+        $configFile = vfsStream::newFile('adr.yml')->at($vfs)->setContent($configContent)->url();
+
         (new Application())->add($this->command);
-        
+
         $tester = new CommandTester($this->command);
 
         $tester->execute([
-            'command'     => $this->command->getName(), 
-            'title'       => 'Foo',
-            '--directory' => $vfs->url(),
+            'command'  => $this->command->getName(),
+            'title'    => 'Foo',
+            '--config' => $configFile,
         ]);
-        
+
         $this->assertRegexp('/ADR created successfully/', $tester->getDisplay());
     }
 }

--- a/tests/Command/MakeDecisionCommandTest.php
+++ b/tests/Command/MakeDecisionCommandTest.php
@@ -59,7 +59,7 @@ class MakeDecisionCommandTest extends TestCase
         $argument = $this->command->getDefinition()->getArgument('status');
         
         $this->assertFalse($argument->isRequired());
-        $this->assertEquals('The status of the ADR, avaliable options: [Proposed, Accepted, Rejected, Deprecated]', $argument->getDescription());
+        $this->assertEquals('The status of the ADR, available options: [Proposed, Accepted, Rejected, Deprecated]', $argument->getDescription());
         $this->assertEquals('Accepted', $argument->getDefault());
     }
     

--- a/tests/Command/WorkspaceCountCommandTest.php
+++ b/tests/Command/WorkspaceCountCommandTest.php
@@ -2,10 +2,10 @@
 
 namespace ADR\Command;
 
-use PHPUnit\Framework\TestCase;
 use org\bovigo\vfs\vfsStream;
-use Symfony\Component\Console\Command\Command;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
 
 class WorkspaceCountCommandTest extends TestCase
@@ -14,70 +14,73 @@ class WorkspaceCountCommandTest extends TestCase
      * @var WorkspaceCountCommand
      */
     private $command;
-    
+
     public function setUp()
     {
         $this->command = new WorkspaceCountCommand();
     }
-    
+
     public function testInstanceOfCommand()
     {
         $this->assertInstanceOf(Command::class, $this->command);
     }
-    
+
     public function testName()
     {
         $this->assertEquals('workspace:count', $this->command->getName());
     }
-    
+
     public function testDescription()
     {
         $this->assertEquals('Count the ADRs', $this->command->getDescription());
     }
-    
+
     public function testHelp()
     {
         $this->assertEquals('This command allows you count the ADRs', $this->command->getHelp());
     }
-    
+
     public function testOptions()
     {
-        $this->assertTrue($this->command->getDefinition()->hasOption('directory'));
-        
+        $this->assertTrue($this->command->getDefinition()->hasOption('config'));
+
         $this->assertCount(1, $this->command->getDefinition()->getOptions());
     }
-    
-    public function testOptionDirectory()
+
+    public function testOptionConfig()
     {
-        $option = $this->command->getDefinition()->getOption('directory');
-        
+        $option = $this->command->getDefinition()->getOption('config');
+
         $this->assertNull($option->getShortcut());
         $this->assertTrue($option->isValueRequired());
-        $this->assertEquals('Workspace that store the ADRs', $option->getDescription());
-        $this->assertEquals('docs/arch', $option->getDefault());
+        $this->assertEquals('Config file', $option->getDescription());
+        $this->assertEquals('adr.yml', $option->getDefault());
     }
-    
+
     public function testExecute()
     {
         $vfs = vfsStream::setup();
-        
+        $configContent = file_get_contents('adr.yml');
+        $configContent = str_replace('docs/arch', $vfs->url(), $configContent);
+        $configFile = vfsStream::newFile('adr.yml')->at($vfs)->setContent($configContent)->url();
+
         $input = [
-            'command'     => $this->command->getName(),
-            '--directory' => $vfs->url(),
+            'command'  => $this->command->getName(),
+            '--config' => $configFile,
         ];
-        
+
         (new Application())->add($this->command);
-        
+
         $tester = new CommandTester($this->command);
         $tester->execute($input);
-        
+
         $this->assertRegexp('/0/', $tester->getDisplay());
-        
+
         $vfs->addChild(vfsStream::newFile('0001-foo.md'));
         $vfs->addChild(vfsStream::newFile('0002-bar.md'));
-        
+
         $tester->execute($input);
-        
+
         $this->assertRegexp('/2/', $tester->getDisplay());
     }
 }

--- a/tests/Command/WorkspaceCountCommandTest.php
+++ b/tests/Command/WorkspaceCountCommandTest.php
@@ -10,6 +10,9 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 class WorkspaceCountCommandTest extends TestCase
 {
+    /**
+     * @var WorkspaceCountCommand
+     */
     private $command;
     
     public function setUp()

--- a/tests/Command/WorkspaceListCommandTest.php
+++ b/tests/Command/WorkspaceListCommandTest.php
@@ -10,6 +10,9 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 class WorkspaceListCommandTest extends TestCase
 {
+    /**
+     * @var WorkspaceListCommand
+     */
     private $command;
     
     public function setUp()

--- a/tests/Command/WorkspaceListCommandTest.php
+++ b/tests/Command/WorkspaceListCommandTest.php
@@ -2,10 +2,10 @@
 
 namespace ADR\Command;
 
-use PHPUnit\Framework\TestCase;
 use org\bovigo\vfs\vfsStream;
-use Symfony\Component\Console\Command\Command;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
 
 class WorkspaceListCommandTest extends TestCase
@@ -42,28 +42,31 @@ class WorkspaceListCommandTest extends TestCase
     
     public function testOptions()
     {
-        $this->assertTrue($this->command->getDefinition()->hasOption('directory'));
+        $this->assertTrue($this->command->getDefinition()->hasOption('config'));
         
         $this->assertCount(1, $this->command->getDefinition()->getOptions());
     }
     
-    public function testOptionDirectory()
+    public function testOptionConfig()
     {
-        $option = $this->command->getDefinition()->getOption('directory');
+        $option = $this->command->getDefinition()->getOption('config');
         
         $this->assertNull($option->getShortcut());
         $this->assertTrue($option->isValueRequired());
-        $this->assertEquals('Workspace that store the ADRs', $option->getDescription());
-        $this->assertEquals('docs/arch', $option->getDefault());
+        $this->assertEquals('Config file', $option->getDescription());
+        $this->assertEquals('adr.yml', $option->getDefault());
     }
     
     public function testExecute()
     {
         $vfs = vfsStream::setup();
+        $configContent = file_get_contents('adr.yml');
+        $configContent = str_replace('docs/arch', $vfs->url(), $configContent);
+        $configFile = vfsStream::newFile('adr.yml')->at($vfs)->setContent($configContent)->url();
         
         $input = [
             'command'     => $this->command->getName(),
-            '--directory' => $vfs->url(),
+            '--config' => $configFile,
         ];
         
         (new Application())->add($this->command);

--- a/tests/Command/WorkspaceListCommandTest.php
+++ b/tests/Command/WorkspaceListCommandTest.php
@@ -14,73 +14,73 @@ class WorkspaceListCommandTest extends TestCase
      * @var WorkspaceListCommand
      */
     private $command;
-    
+
     public function setUp()
     {
         $this->command = new WorkspaceListCommand();
     }
-    
+
     public function testInstanceOfCommand()
     {
         $this->assertInstanceOf(Command::class, $this->command);
     }
-    
+
     public function testName()
     {
         $this->assertEquals('workspace:list', $this->command->getName());
     }
-    
+
     public function testDescription()
     {
         $this->assertEquals('List the ADRs', $this->command->getDescription());
     }
-    
+
     public function testHelp()
     {
         $this->assertEquals('This command allows you list the ADRs', $this->command->getHelp());
     }
-    
+
     public function testOptions()
     {
         $this->assertTrue($this->command->getDefinition()->hasOption('config'));
-        
+
         $this->assertCount(1, $this->command->getDefinition()->getOptions());
     }
-    
+
     public function testOptionConfig()
     {
         $option = $this->command->getDefinition()->getOption('config');
-        
+
         $this->assertNull($option->getShortcut());
         $this->assertTrue($option->isValueRequired());
         $this->assertEquals('Config file', $option->getDescription());
         $this->assertEquals('adr.yml', $option->getDefault());
     }
-    
+
     public function testExecute()
     {
         $vfs = vfsStream::setup();
         $configContent = file_get_contents('adr.yml');
         $configContent = str_replace('docs/arch', $vfs->url(), $configContent);
         $configFile = vfsStream::newFile('adr.yml')->at($vfs)->setContent($configContent)->url();
-        
+
         $input = [
-            'command'     => $this->command->getName(),
+            'command'  => $this->command->getName(),
             '--config' => $configFile,
         ];
-        
+
         (new Application())->add($this->command);
-        
+
         $tester = new CommandTester($this->command);
         $tester->execute($input);
-        
+
         $this->assertRegexp('/Workspace is empty/', $tester->getDisplay());
-        
+
         $vfs->addChild(vfsStream::newFile('0001-foo.md'));
         $vfs->addChild(vfsStream::newFile('0002-bar.md'));
-        
+
         $tester->execute($input);
-        
+
         $this->assertContains('0001-foo.md', $tester->getDisplay());
         $this->assertContains('0002-bar.md', $tester->getDisplay());
     }

--- a/tests/Domain/DecisionContentTest.php
+++ b/tests/Domain/DecisionContentTest.php
@@ -2,8 +2,8 @@
 
 namespace ADR\Domain;
 
-use PHPUnit\Framework\TestCase;
 use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
 
 class DecisionContentTest extends TestCase
 {
@@ -13,20 +13,21 @@ class DecisionContentTest extends TestCase
     public function testInstanceSuccessfully($input, $output)
     {
         $content = new DecisionContent(1, 'Foo', $input);
-        
+
         $this->assertEquals(1, $content->getId());
         $this->assertEquals('Foo', $content->getTitle());
         $this->assertEquals($output, $content->getStatus());
     }
-    
+
     /**
      * @expectedException InvalidArgumentException
      */
     public function testInstanceFailureWithTitle()
     {
-        new DecisionContent(1, 'A very large title should not be used in arquitecture decision record because this attribute must be short noun phrases');
+        new DecisionContent(1,
+            'A very large title should not be used in arquitecture decision record because this attribute must be short noun phrases');
     }
-    
+
     /**
      * @expectedException InvalidArgumentException
      */
@@ -34,7 +35,7 @@ class DecisionContentTest extends TestCase
     {
         new DecisionContent(1, 'Foo', 'Superseded');
     }
-    
+
     public function providerTestInstanceSuccessfully()
     {
         return [
@@ -48,5 +49,5 @@ class DecisionContentTest extends TestCase
             ['deprecated', 'Deprecated'],
         ];
     }
-    
+
 }

--- a/tests/Domain/DecisionRecordTest.php
+++ b/tests/Domain/DecisionRecordTest.php
@@ -2,10 +2,14 @@
 
 namespace ADR\Domain;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class DecisionRecordTest extends TestCase
 {
+    /**
+     * @var DecisionContent|MockObject
+     */
     private $content;
     
     public function setUp()

--- a/tests/Domain/DecisionRecordTest.php
+++ b/tests/Domain/DecisionRecordTest.php
@@ -2,6 +2,7 @@
 
 namespace ADR\Domain;
 
+use ADR\Filesystem\Config;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -11,12 +12,19 @@ class DecisionRecordTest extends TestCase
      * @var DecisionContent|MockObject
      */
     private $content;
+
+    /**
+     * @var Config
+     */
+    private $config;
     
     public function setUp()
     {
         $this->content = $this->getMockBuilder(DecisionContent::class)
             ->disableOriginalConstructor()
             ->getMock();
+
+        $this->config = new Config('adr.yml');
     }
     
     public function testFilename()
@@ -24,7 +32,7 @@ class DecisionRecordTest extends TestCase
         $this->content->expects($this->once())->method('getId')->willReturn(1);
         $this->content->expects($this->once())->method('getTitle')->willReturn('Foo');
         
-        $record = new DecisionRecord($this->content);
+        $record = new DecisionRecord($this->content, $this->config);
         
         $this->assertEquals('0001-foo.md', $record->filename());
     }
@@ -35,7 +43,7 @@ class DecisionRecordTest extends TestCase
         $this->content->expects($this->once())->method('getTitle')->willReturn('Foo');
         $this->content->expects($this->once())->method('getStatus')->willReturn('Accepted');
         
-        $record = new DecisionRecord($this->content);
+        $record = new DecisionRecord($this->content, $this->config);
         
         $output = $record->output();
         

--- a/tests/Domain/DecisionRecordTest.php
+++ b/tests/Domain/DecisionRecordTest.php
@@ -17,7 +17,7 @@ class DecisionRecordTest extends TestCase
      * @var Config
      */
     private $config;
-    
+
     public function setUp()
     {
         $this->content = $this->getMockBuilder(DecisionContent::class)
@@ -26,27 +26,27 @@ class DecisionRecordTest extends TestCase
 
         $this->config = new Config('adr.yml');
     }
-    
+
     public function testFilename()
     {
         $this->content->expects($this->once())->method('getId')->willReturn(1);
         $this->content->expects($this->once())->method('getTitle')->willReturn('Foo');
-        
+
         $record = new DecisionRecord($this->content, $this->config);
-        
+
         $this->assertEquals('0001-foo.md', $record->filename());
     }
-    
+
     public function testOutput()
     {
         $this->content->expects($this->once())->method('getId')->willReturn(1);
         $this->content->expects($this->once())->method('getTitle')->willReturn('Foo');
         $this->content->expects($this->once())->method('getStatus')->willReturn('Accepted');
-        
+
         $record = new DecisionRecord($this->content, $this->config);
-        
+
         $output = $record->output();
-        
+
         $this->assertContains('# 1. Foo', $output);
         $this->assertContains(date('Y-m-d'), $output);
         $this->assertContains('Accepted', $output);

--- a/tests/Domain/SequenceTest.php
+++ b/tests/Domain/SequenceTest.php
@@ -2,12 +2,16 @@
 
 namespace ADR\Domain;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use ADR\Filesystem\Workspace;
 use LogicException;
 
 class SequenceTest extends TestCase
 {
+    /**
+     * @var Workspace|MockObject
+     */
     private $workspace;
     
     public function setUp()

--- a/tests/Domain/SequenceTest.php
+++ b/tests/Domain/SequenceTest.php
@@ -2,10 +2,10 @@
 
 namespace ADR\Domain;
 
-use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\TestCase;
 use ADR\Filesystem\Workspace;
 use LogicException;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
 class SequenceTest extends TestCase
 {
@@ -13,36 +13,36 @@ class SequenceTest extends TestCase
      * @var Workspace|MockObject
      */
     private $workspace;
-    
+
     public function setUp()
     {
         $this->workspace = $this->getMockBuilder(Workspace::class)
             ->disableOriginalConstructor()
             ->getMock();
     }
-    
+
     /**
      * @dataProvider providerTestNextSuccessfully
      */
     public function testNextSuccessfully($count, $expected)
     {
         $sequence = new Sequence($this->workspace);
-        
+
         $this->workspace->expects($this->once())->method('count')->willReturn($count);
-        
+
         $this->assertEquals($expected, $sequence->next());
     }
-    
+
     public function testNextFailure()
     {
         $this->expectException(LogicException::class);
-        
+
         $this->workspace->expects($this->once())->method('count')->willReturn(Sequence::MAX_VALUE);
-        
+
         $sequence = new Sequence($this->workspace);
         $sequence->next();
     }
-    
+
     public function providerTestNextSuccessfully()
     {
         return [

--- a/tests/Filesystem/ConfigTest.php
+++ b/tests/Filesystem/ConfigTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace ADR\Filesystem;
+
+use RuntimeException;
+use PHPUnit\Framework\TestCase;
+
+class ConfigTest extends TestCase
+{
+    public function testInstanceSuccessfully()
+    {
+        $config = new Config(__DIR__ . '/../../adr.yml');
+
+        $this->assertEquals('docs/arch', $config->directory());
+        $this->assertEquals('template/skeleton.md', $config->decisionRecordTemplateFile());
+    }
+
+    public function testInstanceFailure()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The config file does not exist: invalid.yml');
+
+        new Config('invalid.yml');
+    }
+}

--- a/tests/Filesystem/ConfigTest.php
+++ b/tests/Filesystem/ConfigTest.php
@@ -3,8 +3,8 @@
 namespace ADR\Filesystem;
 
 use org\bovigo\vfs\vfsStream;
-use RuntimeException;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 class ConfigTest extends TestCase
 {

--- a/tests/Filesystem/ConfigTest.php
+++ b/tests/Filesystem/ConfigTest.php
@@ -2,6 +2,7 @@
 
 namespace ADR\Filesystem;
 
+use org\bovigo\vfs\vfsStream;
 use RuntimeException;
 use PHPUnit\Framework\TestCase;
 
@@ -15,11 +16,22 @@ class ConfigTest extends TestCase
         $this->assertEquals('template/skeleton.md', $config->decisionRecordTemplateFile());
     }
 
-    public function testInstanceFailure()
+    public function testInstanceNotExistingFailure()
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('The config file does not exist: invalid.yml');
 
         new Config('invalid.yml');
+    }
+
+    public function testInstanceNotReadableFailure()
+    {
+        $vfs = vfsStream::setup();
+        $configFile = vfsStream::newFile('adr.yml')->at($vfs)->chmod(0)->url();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage("The config file isn't readable: $configFile");
+
+        new Config($configFile);
     }
 }

--- a/tests/Filesystem/WorkspaceTest.php
+++ b/tests/Filesystem/WorkspaceTest.php
@@ -2,9 +2,9 @@
 
 namespace ADR\Filesystem;
 
-use PHPUnit\Framework\TestCase;
-use org\bovigo\vfs\vfsStream;
 use ADR\Domain\DecisionRecord;
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
 class WorkspaceTest extends TestCase
@@ -12,55 +12,55 @@ class WorkspaceTest extends TestCase
     public function testSetSuccessfully()
     {
         $directory = vfsStream::setup()->url() . '/docs/arch';
-        
+
         $workspace = new Workspace($directory);
-        
+
         $this->assertEquals($directory, $workspace->get());
         $this->assertDirectoryIsWritable($workspace->get());
     }
-    
+
     public function testSetFailure()
     {
         $this->expectException(RuntimeException::class);
-        
+
         new Workspace('/path/to/docs/arch');
     }
-    
+
     public function testCount()
     {
         $vfs = vfsStream::setup();
-        
+
         $workspace = new Workspace($vfs->url());
 
         $this->assertEquals(0, $workspace->count());
-        
+
         $vfs->addChild(vfsStream::newFile('0001-foo.md'));
         $vfs->addChild(vfsStream::newFile('0002-bar.md'));
         $vfs->addChild(vfsStream::newFile('0003-baz-2.md'));
-        
+
         $vfs->addChild(vfsStream::newFile('0004-snake_case.md'));
         $vfs->addChild(vfsStream::newFile('0005-UPPERCASE.md'));
         $vfs->addChild(vfsStream::newFile('0006-CamelCase.md'));
         $vfs->addChild(vfsStream::newFile('any-file.md'));
         $vfs->addChild(vfsStream::newDirectory('any-directory'));
-        
+
         $this->assertEquals(3, $workspace->count());
     }
-    
+
     public function testAdd()
     {
         $vfs = vfsStream::setup();
-        
+
         $record = $this->getMockBuilder(DecisionRecord::class)
             ->disableOriginalConstructor()
             ->getMock();
-        
+
         $record->expects($this->once())->method('filename')->willReturn('0001-foo.md');
         $record->expects($this->once())->method('output');
-        
+
         $workspace = new Workspace($vfs->url());
         $workspace->add($record);
-        
+
         $this->assertFileExists($vfs->url() . '/0001-foo.md');
     }
 }


### PR DESCRIPTION
I would like to use my own ADR template and unfortunately it was not possible. Therefore I introduced a configuration file. Additionally I made the workspace directory configurable via configuration file as well. That's why I removed the "directory" option from the commands.

This is of course a BC, but in my opinion it should not be a big problem for this project.

It would also be very helpful to have a table of contents for all ADRs. What do you think?